### PR TITLE
Fix: Standardize metric card heights on Dashboard

### DIFF
--- a/RUNSTR IOS/Views/DashboardView.swift
+++ b/RUNSTR IOS/Views/DashboardView.swift
@@ -135,7 +135,7 @@ struct DashboardView: View {
                     .foregroundColor(.runstrGray)
             }
             .padding(RunstrSpacing.lg)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(maxWidth: .infinity, minHeight: 85, alignment: .leading)
             .runstrCard()
             
             // Time card
@@ -154,7 +154,7 @@ struct DashboardView: View {
                     .foregroundColor(.runstrWhite)
             }
             .padding(RunstrSpacing.lg)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(maxWidth: .infinity, minHeight: 85, alignment: .leading)
             .runstrCard()
             
             // Activity-specific metric card
@@ -210,7 +210,7 @@ struct DashboardView: View {
                 }
             }
             .padding(RunstrSpacing.lg)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(maxWidth: .infinity, minHeight: 85, alignment: .leading)
             .runstrCard()
             
             // Elevation card with directional indicators
@@ -274,7 +274,7 @@ struct DashboardView: View {
                 }
             }
             .padding(RunstrSpacing.lg)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(maxWidth: .infinity, minHeight: 85, alignment: .leading)
             .runstrCard()
         }
     }


### PR DESCRIPTION
Fixes #3

Standardizes all metric card heights in the Dashboard 2x2 grid for consistent visual appearance.

## Changes
- Added `minHeight: 85` to all 4 metric cards
- Fixes Time card appearing smaller than other cards
- Maintains existing spacing and alignment
- Preserves responsive design principles

## Testing
- All cards now have identical heights
- Content fits properly including elevation indicators
- No impact on readability or visual hierarchy

Generated with [Claude Code](https://claude.ai/code)