### PR TITLE
Add Nostr login option to login screen

### DIFF
--- a/RUNSTR IOS/Models/User.swift
+++ b/RUNSTR IOS/Models/User.swift
@@ -55,6 +55,7 @@ struct User: Codable, Identifiable {
 
 enum LoginMethod: String, Codable {
     case apple
+    case nostr
 }
 
 struct NostrProfile: Codable {

--- a/RUNSTR IOS/Views/OnboardingView.swift
+++ b/RUNSTR IOS/Views/OnboardingView.swift
@@ -5,6 +5,7 @@ struct OnboardingView: View {
     @EnvironmentObject var authService: AuthenticationService
     @EnvironmentObject var nostrService: NostrService
     @State private var currentPage = 0
+    @State private var showingNostrLogin = false
     
     private let onboardingPages = [
         OnboardingPage(
@@ -75,6 +76,30 @@ struct OnboardingView: View {
                     }
                     .disabled(authService.isLoading)
                     
+                    // Nostr Login Button
+                    Button {
+                        showingNostrLogin = true
+                    } label: {
+                        HStack(spacing: 12) {
+                            Image(systemName: "key.horizontal")
+                                .font(.title3)
+                            Text("Login with Nostr")
+                                .font(.system(size: 16, weight: .medium))
+                        }
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 50)
+                        .background(
+                            LinearGradient(
+                                gradient: Gradient(colors: [Color.purple, Color.orange]),
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                        )
+                        .cornerRadius(2)
+                    }
+                    .disabled(authService.isLoading)
+                    
                 } else {
                     Button("Next") {
                         withAnimation {
@@ -103,6 +128,10 @@ struct OnboardingView: View {
         .background(Color.black)
         .foregroundColor(.white)
         .ignoresSafeArea(edges: .bottom)
+        .sheet(isPresented: $showingNostrLogin) {
+            NostrLoginSheet()
+                .environmentObject(authService)
+        }
     }
 }
 
@@ -160,6 +189,268 @@ struct OnboardingPage {
     let imageName: String
     let description: String
     let isLogo: Bool
+}
+
+struct NostrLoginSheet: View {
+    @EnvironmentObject var authService: AuthenticationService
+    @Environment(\.dismiss) private var dismiss
+    @State private var nsecInput = ""
+    @State private var isLoading = false
+    @State private var errorMessage = ""
+    @State private var showingKeyGenerator = false
+    
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 24) {
+                // Header
+                VStack(spacing: 12) {
+                    Image(systemName: "key.horizontal.fill")
+                        .font(.system(size: 48))
+                        .foregroundColor(.orange)
+                    
+                    Text("Login with Nostr")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    
+                    Text("Enter your private key (nsec) to sign in")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .padding(.top, 20)
+                
+                // Input Section
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Private Key (nsec)")
+                        .font(.headline)
+                    
+                    SecureField("nsec1...", text: $nsecInput)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .autocapitalization(.none)
+                        .disableAutocorrection(true)
+                    
+                    if !errorMessage.isEmpty {
+                        Text(errorMessage)
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+                }
+                
+                // Action Buttons
+                VStack(spacing: 12) {
+                    Button {
+                        Task {
+                            await signInWithKey()
+                        }
+                    } label: {
+                        HStack {
+                            if isLoading {
+                                ProgressView()
+                                    .progressViewStyle(CircularProgressViewStyle())
+                                    .scaleEffect(0.8)
+                            }
+                            Text(isLoading ? "Signing In..." : "Sign In")
+                        }
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 50)
+                        .background(nsecInput.isEmpty ? Color.gray : Color.orange)
+                        .foregroundColor(.white)
+                        .cornerRadius(12)
+                    }
+                    .disabled(nsecInput.isEmpty || isLoading)
+                    
+                    Button {
+                        showingKeyGenerator = true
+                    } label: {
+                        Text("Generate New Nostr Key")
+                            .foregroundColor(.orange)
+                    }
+                }
+                
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("Nostr Login")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+        .sheet(isPresented: $showingKeyGenerator) {
+            NostrKeyGeneratorSheet()
+                .environmentObject(authService)
+        }
+    }
+    
+    private func signInWithKey() async {
+        isLoading = true
+        errorMessage = ""
+        
+        let success = await authService.signInWithNostrKey(nsecInput)
+        
+        await MainActor.run {
+            isLoading = false
+            if success {
+                dismiss()
+            } else {
+                errorMessage = "Invalid private key. Please check your nsec and try again."
+            }
+        }
+    }
+}
+
+struct NostrKeyGeneratorSheet: View {
+    @EnvironmentObject var authService: AuthenticationService
+    @Environment(\.dismiss) private var dismiss
+    @State private var generatedKeyPair: NostrKeyPair?
+    @State private var isLoading = false
+    @State private var keyCopied = false
+    
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 24) {
+                // Header
+                VStack(spacing: 12) {
+                    Image(systemName: "key.viewfinder")
+                        .font(.system(size: 48))
+                        .foregroundColor(.orange)
+                    
+                    Text("Generate Nostr Keys")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    
+                    Text("We'll create a new Nostr identity for you")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .padding(.top, 20)
+                
+                if let keyPair = generatedKeyPair {
+                    VStack(spacing: 16) {
+                        // Public Key
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Public Key (npub)")
+                                .font(.headline)
+                            
+                            Text(keyPair.publicKey)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .padding(12)
+                                .background(Color.gray.opacity(0.1))
+                                .cornerRadius(8)
+                        }
+                        
+                        // Private Key
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                Text("Private Key (nsec)")
+                                    .font(.headline)
+                                Spacer()
+                                Button {
+                                    UIPasteboard.general.string = keyPair.privateKey
+                                    keyCopied = true
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                        keyCopied = false
+                                    }
+                                } label: {
+                                    HStack(spacing: 4) {
+                                        Image(systemName: keyCopied ? "checkmark" : "doc.on.doc")
+                                        Text(keyCopied ? "Copied!" : "Copy")
+                                    }
+                                    .font(.caption)
+                                    .foregroundColor(.orange)
+                                }
+                            }
+                            
+                            Text(keyPair.privateKey)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .padding(12)
+                                .background(Color.gray.opacity(0.1))
+                                .cornerRadius(8)
+                        }
+                        
+                        Text("⚠️ Save your private key securely. You'll need it to access your account.")
+                            .font(.caption)
+                            .foregroundColor(.orange)
+                            .multilineTextAlignment(.center)
+                            .padding()
+                    }
+                    
+                    Button {
+                        Task {
+                            await useGeneratedKey()
+                        }
+                    } label: {
+                        HStack {
+                            if isLoading {
+                                ProgressView()
+                                    .progressViewStyle(CircularProgressViewStyle())
+                                    .scaleEffect(0.8)
+                            }
+                            Text(isLoading ? "Creating Account..." : "Use This Key")
+                        }
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 50)
+                        .background(Color.orange)
+                        .foregroundColor(.white)
+                        .cornerRadius(12)
+                    }
+                    .disabled(isLoading)
+                    
+                } else {
+                    Button {
+                        generateNewKey()
+                    } label: {
+                        Text("Generate New Key")
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 50)
+                            .background(Color.orange)
+                            .foregroundColor(.white)
+                            .cornerRadius(12)
+                    }
+                }
+                
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("Generate Keys")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+    
+    private func generateNewKey() {
+        // Use the existing NostrService method to generate keys
+        if let keyPair = NostrService().generateRunstrKeys() {
+            generatedKeyPair = keyPair
+        }
+    }
+    
+    private func useGeneratedKey() async {
+        guard let keyPair = generatedKeyPair else { return }
+        
+        isLoading = true
+        let success = await authService.signInWithNostrKey(keyPair.privateKey)
+        
+        await MainActor.run {
+            isLoading = false
+            if success {
+                dismiss()
+            }
+        }
+    }
 }
 
 #Preview {


### PR DESCRIPTION
Implements Nostr authentication alongside Apple Sign-In

- Add "Login with Nostr" button below Apple Sign-In with gradient styling
- Implement NostrLoginSheet for nsec key authentication
- Add NostrKeyGeneratorSheet for creating new Nostr identities
- Add signInWithNostrKey() method in AuthenticationService
- Extend LoginMethod enum to support .nostr authentication
- Include secure key validation using NostrSDK 0.3.0
- Add copy-to-clipboard functionality for generated keys
- Integrate with existing keychain storage and authentication flow

Fixes #10

Generated with [Claude Code](https://claude.ai/code)